### PR TITLE
Add container-fluid at base

### DIFF
--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -1,7 +1,7 @@
 {% extends 'VictoireCoreBundle:Widget:show.html.twig' %}
 
 {% block content %}
-    <div class="vic-layout{% if hasContainer %} container{% endif %}">
+    <div class="vic-layout{% if hasContainer %} container{% else %} container-fluid{% endif %}">
         {% set availableWidgets = [] %}
         <div class="row">
 


### PR DESCRIPTION
Made because to avoid horizontal scrolling in the page caused by the negatives margin of the children .row element
